### PR TITLE
fix: graceful handling of multi-module ABC decompilation

### DIFF
--- a/algos.cpp
+++ b/algos.cpp
@@ -100,8 +100,16 @@ std::vector<uint32_t> TopologicalSort(const std::vector<std::pair<uint32_t, uint
     }
     
     if (result.size() != allNodes.size()) {
-        HandleError("#TopologicalSort: search failed");
-        return {}; 
+        // Cycle detected in dependency graph (likely due to skipped methods).
+        // Add remaining nodes in arbitrary order rather than aborting.
+        std::cerr << "Warning: TopologicalSort cycle detected ("
+                  << result.size() << "/" << allNodes.size()
+                  << " nodes resolved), adding remaining nodes" << std::endl;
+        for (uint32_t node : allNodes) {
+            if (std::find(result.begin(), result.end(), node) == result.end()) {
+                result.push_back(node);
+            }
+        }
     }
     
     return result;

--- a/astgen.cpp
+++ b/astgen.cpp
@@ -349,10 +349,14 @@ uint32_t onlyOneBranch(BasicBlock* father, AstGen * enc){
     std::cout << "other_fater: " << std::to_string(other_father->GetId()) << std::endl;
 
     uint32_t count = 0;
+    const uint32_t MAX_ITERATIONS = 10000;
     while(other_father != father && other_father != start_block){
-        std::cout << "count: " << count << std::endl;
+        count++;
+        if (count > MAX_ITERATIONS) {
+            std::cerr << "Warning: onlyOneBranch loop exceeded " << MAX_ITERATIONS << " iterations, breaking" << std::endl;
+            return 0;
+        }
         other_father = other_father->GetPredecessor(0);
-        std::cout << "predecessor id: " << other_father->GetId() << std::endl;
     }
 
     if(other_father == father ){
@@ -689,7 +693,18 @@ void AstGen::VisitCastValueToAnyType(GraphVisitor *visitor, Inst *inst)
     auto enc = static_cast<AstGen *>(visitor);
 
     auto cvat = inst->CastToCastValueToAnyType();
-    auto input = cvat->GetInput(0).GetInst()->CastToConstant();
+    auto input_inst = cvat->GetInput(0).GetInst();
+    // Input can be Constant (for int/double/bool/null/undefined) or LoadString (for string type)
+    compiler::ConstantInst *input = nullptr;
+    if (input_inst->GetOpcode() == compiler::Opcode::Constant) {
+        input = input_inst->CastToConstant();
+    } else if (input_inst->GetOpcode() != compiler::Opcode::LoadString) {
+        // Neither Constant nor LoadString - handle gracefully
+        std::cerr << "Warning: VisitCastValueToAnyType: unexpected input opcode "
+                  << static_cast<int>(input_inst->GetOpcode()) << std::endl;
+        enc->SetExpressionByRegister(inst, inst->GetDstReg(), enc->constant_undefined);
+        return;
+    }
 
     es2panda::ir::Expression* source = nullptr;
     switch (cvat->GetAnyType()) {
@@ -703,20 +718,23 @@ void AstGen::VisitCastValueToAnyType(GraphVisitor *visitor, Inst *inst)
         }
 
         case compiler::AnyBaseType::ECMASCRIPT_INT_TYPE: {
-            source = AllocNode<es2panda::ir::NumberLiteral>(enc, 
+            if (!input) { enc->success_ = false; break; }
+            source = AllocNode<es2panda::ir::NumberLiteral>(enc,
                                                                 input->CastToConstant()->GetIntValue()
                                             );
             break;
         }
 
         case compiler::AnyBaseType::ECMASCRIPT_DOUBLE_TYPE: {
-            source = AllocNode<es2panda::ir::NumberLiteral>(enc, 
+            if (!input) { enc->success_ = false; break; }
+            source = AllocNode<es2panda::ir::NumberLiteral>(enc,
                                                                 input->CastToConstant()->GetDoubleValue()
                                                         );
             break;
         }
 
         case compiler::AnyBaseType::ECMASCRIPT_BOOLEAN_TYPE: {
+            if (!input) { enc->success_ = false; break; }
             uint64_t val = input->GetInt64Value();
             if (val != 0) {
                 source = enc->constant_true;

--- a/base.h
+++ b/base.h
@@ -68,8 +68,8 @@
 static int count = 0;
 
 inline void HandleInnerError(const std::string& message) {
-    std::cerr << "Error: " << message << std::endl;
-    std::exit(EXIT_FAILURE);
+    std::cerr << "Warning: " << message << std::endl;
+    throw std::runtime_error(message);
 }
 
 template<typename... Args>

--- a/classconstruction.cpp
+++ b/classconstruction.cpp
@@ -35,7 +35,8 @@ bool ConstructClasses(std::map<uint32_t, std::set<uint32_t>> &class2memberfuns, 
         if(raw2newname.find(constructor_offset_name) != raw2newname.end()){
             newname_constructor_offset_name =  raw2newname[constructor_offset_name];
         }else{
-            HandleError("#ConstructClasses: find constructor_offset_name newname error");
+            std::cerr << "Warning: ConstructClasses: no newname for constructor " << constructor_offset_name << ", skipping class" << std::endl;
+            continue;
         }
         panda::es2panda::util::StringView name_view1 = panda::es2panda::util::StringView(*(new std::string(RemoveArgumentsOfFunc(newname_constructor_offset_name))));
 
@@ -54,11 +55,16 @@ bool ConstructClasses(std::map<uint32_t, std::set<uint32_t>> &class2memberfuns, 
         panda::es2panda::util::StringView name_view2 = panda::es2panda::util::StringView("constructor");
         auto keyNode = AllocNode<panda::es2panda::ir::Identifier>(parser_program, name_view2);
 
-        auto func = method2scriptfunast[constructor_offset];
-        method2scriptfunast.erase(constructor_offset);
+        panda::es2panda::ir::ScriptFunction *func = nullptr;
+        if(method2scriptfunast.find(constructor_offset) != method2scriptfunast.end()){
+            func = method2scriptfunast[constructor_offset];
+            method2scriptfunast.erase(constructor_offset);
+        }
 
         if(func == nullptr){
-            HandleError("#DecompilePandaFile: find constructor function fail!");
+            // Constructor was skipped during decompilation - skip this class
+            std::cerr << "Warning: ConstructClasses: constructor " << constructor_offset << " not decompiled, skipping class" << std::endl;
+            continue;
         }
 
         auto funcExpr = AllocNode<panda::es2panda::ir::FunctionExpression>(parser_program, func);
@@ -84,12 +90,16 @@ bool ConstructClasses(std::map<uint32_t, std::set<uint32_t>> &class2memberfuns, 
                 continue;
             }
             
-            auto func = method2scriptfunast[member_func_offset];
-            method2scriptfunast.erase(member_func_offset);
+            panda::es2panda::ir::ScriptFunction *func = nullptr;
+            if(method2scriptfunast.find(member_func_offset) != method2scriptfunast.end()){
+                func = method2scriptfunast[member_func_offset];
+                method2scriptfunast.erase(member_func_offset);
+            }
 
             if(func == nullptr){
-                std::cout << "member function offset: " << member_func_offset << std::endl;
-                HandleError("#ConstructClasses: find member function fail!");
+                // Member method was skipped during decompilation - skip it
+                std::cerr << "Warning: ConstructClasses: member " << member_func_offset << " not decompiled, skipping" << std::endl;
+                continue;
             }
 
             auto funcExpr = AllocNode<es2panda::ir::FunctionExpression>(parser_program, func);
@@ -100,7 +110,8 @@ bool ConstructClasses(std::map<uint32_t, std::set<uint32_t>> &class2memberfuns, 
             if(raw2newname.find(raw_member_name) != raw2newname.end()){
                 new_member_name =  raw2newname[raw_member_name];
             }else{
-                HandleError("#ConstructClasses: find new_member_name newname error");
+                std::cerr << "Warning: ConstructClasses: no newname for member " << raw_member_name << ", skipping" << std::endl;
+                continue;
             }
 
             panda::es2panda::util::StringView name_view3 = panda::es2panda::util::StringView(*(new std::string(new_member_name)));

--- a/fundepscan.cpp
+++ b/fundepscan.cpp
@@ -114,11 +114,20 @@ void FunDepScan::VisitEcma(panda::compiler::GraphVisitor *visitor, Inst *inst_ba
             auto member_functions = GetLiteralArrayByOffset(enc->program_, literalarray_offset);
             if(member_functions){
                 for(auto const& member_function : *member_functions){
-                    if (enc->methodname2offset_->find(member_function) != enc->methodname2offset_->end()) {
-                        auto memeber_offset = (*enc->methodname2offset_)[member_function];
-                        (*enc->class2memberfuns_)[constructor_offset].insert(memeber_offset);
-                    }else{
-                        HandleError("#function dep scan: DEFINECLASSWITHBUFFER");
+                    // Literal array contains short names (e.g. "#~@0>#clickBondPhone")
+                    // but methodname2offset_ has fully-qualified names.
+                    // Use substring matching (consistent with CREATEOBJECTWITHBUFFER handling).
+                    bool found = false;
+                    for (const auto& pair : *enc->methodname2offset_) {
+                        if(pair.first.find(member_function) != std::string::npos){
+                            (*enc->class2memberfuns_)[constructor_offset].insert(pair.second);
+                            found = true;
+                            break;
+                        }
+                    }
+                    if(!found){
+                        // Skip unresolved members instead of aborting.
+                        // This happens with external/inherited methods.
                     }
                 }
             }

--- a/lexicalenv.cpp
+++ b/lexicalenv.cpp
@@ -210,11 +210,14 @@ void LexicalEnvStack::CheckIndex(size_t A, size_t B) const {
 
 void LexicalEnvStack::CheckStackIndex(size_t A) const {
     if (stack_.empty()) {
-        HandleError("#LexicalEnvStack::CheckStackIndex: Stack is empty");
+        std::cerr << "Warning: LexicalEnvStack::CheckStackIndex: Stack is empty" << std::endl;
+        throw std::runtime_error("LexicalEnvStack empty");
     }
-    
+
     if (A >= stack_.size()) {
-        HandleError("#LexicalEnvStack::CheckStackIndex: Stack index A out of range");
+        std::cerr << "Warning: LexicalEnvStack::CheckStackIndex: Stack index "
+                  << A << " >= size " << stack_.size() << std::endl;
+        throw std::runtime_error("LexicalEnvStack index out of range");
     }
 }
 

--- a/xabc.cpp
+++ b/xabc.cpp
@@ -10,6 +10,21 @@
 #include "fundepscan.h"
 #include "algos.h"
 #include "classconstruction.h"
+#include <signal.h>
+#include <setjmp.h>
+
+// Signal handler for catching SIGSEGV/SIGABRT during decompilation
+static sigjmp_buf s_jmpbuf;
+static volatile sig_atomic_t s_in_decompile = 0;
+
+static void crash_handler(int sig) {
+    if (s_in_decompile) {
+        siglongjmp(s_jmpbuf, sig);
+    }
+    // Not in decompile - default behavior
+    signal(sig, SIG_DFL);
+    raise(sig);
+}
 
 using namespace std;
 using namespace panda;
@@ -539,26 +554,23 @@ bool DecompilePandaFile(pandasm::Program *prog, BytecodeOptIrInterface *ir_inter
 
         panda_file::ClassDataAccessor cda {*pfile, record_id};
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        bool has_error = false;
-        cda.EnumerateMethods([prog, &has_error, &disasm, ir_interface, is_dynamic, &depedges, &class2memberfuns, &method2lexicalmap, &memberfuncs, &raw2newname, &methodname2offset, &skipfailfuns, &inserted_construct_order, &construct2initializer, &construct2staticinitializer, &construct2definedmethod](panda_file::MethodDataAccessor &mda){
+        cda.EnumerateMethods([prog, &disasm, ir_interface, is_dynamic, &depedges, &class2memberfuns, &method2lexicalmap, &memberfuncs, &raw2newname, &methodname2offset, &skipfailfuns, &inserted_construct_order, &construct2initializer, &construct2staticinitializer, &construct2definedmethod](panda_file::MethodDataAccessor &mda){
             if (!mda.IsExternal()) {
                 
                 int32_t res = ScanFunDep(prog, disasm, ir_interface, &depedges, &class2memberfuns, &method2lexicalmap, &memberfuncs, &raw2newname, &methodname2offset, mda, &inserted_construct_order, &construct2initializer, &construct2staticinitializer, &construct2definedmethod, is_dynamic);
-                if(res == 3 || res == 4){
+                if(res != 0){
+                    // Gracefully skip failed methods instead of aborting.
+                    // This allows decompilation of large multi-module ABC files
+                    // where some methods may use unsupported instructions.
                     skipfailfuns.insert(mda.GetMethodId().GetOffset());
                     return;
-                }
-
-                if(res != 0){
-                    has_error = true;
                 }
 
             }
         });
         
-        if(has_error){
-            return false;
-        }
+        // Continue processing even if some methods fail scanning.
+        // Failed methods are already added to skipfailfuns.
     } 
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -583,10 +595,27 @@ bool DecompilePandaFile(pandasm::Program *prog, BytecodeOptIrInterface *ir_inter
             continue;
         }
 
-        result = DecompileFunction(prog, parser_program, ir_interface, mda, is_dynamic, &method2lexicalenvstack, &method2sendablelexicalenvstack, &patchvarspace, index2importnamespaces, localnamespaces, &class2memberfuns, &method2scriptfunast, &ctor2classdeclast, &memberfuncs, &class2father, &method2lexicalmap, &globallexical_waitlist, &globalsendablelexical_waitlist, &raw2newname, &methodname2offset);
-        
+        // Use signal handler to catch SIGSEGV/SIGABRT in decompilation
+        signal(SIGSEGV, crash_handler);
+        signal(SIGABRT, crash_handler);
+        s_in_decompile = 1;
+        int sig = sigsetjmp(s_jmpbuf, 1);
+        if (sig == 0) {
+            try {
+                result = DecompileFunction(prog, parser_program, ir_interface, mda, is_dynamic, &method2lexicalenvstack, &method2sendablelexicalenvstack, &patchvarspace, index2importnamespaces, localnamespaces, &class2memberfuns, &method2scriptfunast, &ctor2classdeclast, &memberfuncs, &class2father, &method2lexicalmap, &globallexical_waitlist, &globalsendablelexical_waitlist, &raw2newname, &methodname2offset);
+            } catch (const std::exception& e) {
+                std::cerr << "Warning: DecompileFunction case 1 exception for offset " << methodoffset << ": " << e.what() << std::endl;
+                result = false;
+            }
+        } else {
+            std::cerr << "Warning: DecompileFunction case 1 crashed (signal " << sig << ") for offset " << methodoffset << ", skipping" << std::endl;
+            result = false;
+        }
+        s_in_decompile = 0;
+        signal(SIGSEGV, SIG_DFL);
+        signal(SIGABRT, SIG_DFL);
         if(!result){
-            HandleError("#DecompilePandaFile: decomiple case 1 failed!");
+            result = true;
         }
     }
 
@@ -597,17 +626,34 @@ bool DecompilePandaFile(pandasm::Program *prog, BytecodeOptIrInterface *ir_inter
         }
         panda_file::ClassDataAccessor cda {*pfile, record_id};
 
-        cda.EnumerateMethods([prog, parser_program, ir_interface, is_dynamic, &result, &method2lexicalenvstack, &method2sendablelexicalenvstack, &patchvarspace, &index2importnamespaces, &localnamespaces, &class2memberfuns, &method2scriptfunast, &ctor2classdeclast, &memberfuncs, &class2father, &method2lexicalmap, &globallexical_waitlist, &globalsendablelexical_waitlist, &raw2newname, &methodname2offset, sorted_methodoffsets, &skipfailfuns](panda_file::MethodDataAccessor &mda){           
+        cda.EnumerateMethods([prog, parser_program, ir_interface, is_dynamic, &result, &method2lexicalenvstack, &method2sendablelexicalenvstack, &patchvarspace, &index2importnamespaces, &localnamespaces, &class2memberfuns, &method2scriptfunast, &ctor2classdeclast, &memberfuncs, &class2father, &method2lexicalmap, &globallexical_waitlist, &globalsendablelexical_waitlist, &raw2newname, &methodname2offset, sorted_methodoffsets, &skipfailfuns](panda_file::MethodDataAccessor &mda){
             if (!mda.IsExternal() && std::find(sorted_methodoffsets.begin(), sorted_methodoffsets.end(), mda.GetMethodId().GetOffset()) == sorted_methodoffsets.end() ){
                             uint32_t cur_method = mda.GetMethodId().GetOffset();
                 if(skipfailfuns.find(cur_method) != skipfailfuns.end()){
-                    
+
                     return;
                 }
-                
-                result = DecompileFunction(prog, parser_program, ir_interface, mda, is_dynamic, &method2lexicalenvstack, &method2sendablelexicalenvstack, &patchvarspace, index2importnamespaces, localnamespaces, &class2memberfuns, &method2scriptfunast, &ctor2classdeclast, &memberfuncs, &class2father, &method2lexicalmap, &globallexical_waitlist, &globalsendablelexical_waitlist, &raw2newname, &methodname2offset);
+
+                signal(SIGSEGV, crash_handler);
+                signal(SIGABRT, crash_handler);
+                s_in_decompile = 1;
+                int sig2 = sigsetjmp(s_jmpbuf, 1);
+                if (sig2 == 0) {
+                    try {
+                        result = DecompileFunction(prog, parser_program, ir_interface, mda, is_dynamic, &method2lexicalenvstack, &method2sendablelexicalenvstack, &patchvarspace, index2importnamespaces, localnamespaces, &class2memberfuns, &method2scriptfunast, &ctor2classdeclast, &memberfuncs, &class2father, &method2lexicalmap, &globallexical_waitlist, &globalsendablelexical_waitlist, &raw2newname, &methodname2offset);
+                    } catch (const std::exception& e) {
+                        std::cerr << "Warning: DecompileFunction case 2 exception for offset " << cur_method << ": " << e.what() << std::endl;
+                        result = false;
+                    }
+                } else {
+                    std::cerr << "Warning: DecompileFunction case 2 crashed (signal " << sig2 << ") for offset " << cur_method << ", skipping" << std::endl;
+                    result = false;
+                }
+                s_in_decompile = 0;
+                signal(SIGSEGV, SIG_DFL);
+                signal(SIGABRT, SIG_DFL);
                 if(!result){
-                    HandleError("#DecompilePandaFile: decomiple case 2 failed!");
+                    result = true;
                 }
             }
         });
@@ -616,11 +662,23 @@ bool DecompilePandaFile(pandasm::Program *prog, BytecodeOptIrInterface *ir_inter
 
     std::cout <<  "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" << std::endl;
 
-    ConstructClasses(class2memberfuns, parser_program, ir_interface, class2father, method2scriptfunast, ctor2classdeclast, raw2newname);
+    signal(SIGSEGV, crash_handler);
+    signal(SIGABRT, crash_handler);
+    s_in_decompile = 1;
+    int sig_cc = sigsetjmp(s_jmpbuf, 1);
+    if (sig_cc == 0) {
+        ConstructClasses(class2memberfuns, parser_program, ir_interface, class2father, method2scriptfunast, ctor2classdeclast, raw2newname);
+    } else {
+        std::cerr << "Warning: ConstructClasses crashed (signal " << sig_cc << "), continuing with partial output" << std::endl;
+    }
+    s_in_decompile = 0;
+    signal(SIGSEGV, SIG_DFL);
+    signal(SIGABRT, SIG_DFL);
 
     std::cout <<  "DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD" << std::endl;
 
     for (auto it = method2scriptfunast.begin(); it != method2scriptfunast.end(); ++it) {
+        if(it->second == nullptr) continue;
         auto funcDecl = AllocNode<panda::es2panda::ir::FunctionDeclaration>(parser_program, it->second);
 
         program_ast->AddStatementAtPos(program_ast->Statements().size(), funcDecl);
@@ -631,6 +689,7 @@ bool DecompilePandaFile(pandasm::Program *prog, BytecodeOptIrInterface *ir_inter
     }
 
     for (auto it = ctor2classdeclast.begin(); it != ctor2classdeclast.end(); ++it) {
+        if(it->second == nullptr) continue;
         program_ast->AddStatementAtPos(program_ast->Statements().size(), it->second);
         
         //std::cout << it->first << " MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM" << std::endl;


### PR DESCRIPTION
## Summary

Enable xabc to decompile real-world multi-module ABC files (e.g., 10MB+ HarmonyOS apps with 29,000+ methods) by fixing 10 issues that previously caused crashes or early termination.

## Problem

xabc crashes immediately when decompiling production HarmonyOS APKs that use ArkUI-X. The first `DEFINECLASSWITHBUFFER` instruction causes an abort because member function names in the literal array don't exactly match the fully-qualified names in `methodname2offset_`.

## Changes

| File | Fix | Impact |
|------|-----|--------|
| `fundepscan.cpp` | Substring matching for DEFINECLASSWITHBUFFER members | Eliminates primary crash |
| `xabc.cpp` | Skip failed methods instead of aborting | Continues decompilation |
| `algos.cpp` | Handle cyclic dependencies in TopologicalSort | Prevents abort on complex graphs |
| `base.h` | HandleInnerError throws exception instead of exit() | Catchable errors |
| `lexicalenv.cpp` | Stack bounds check throws instead of exit() | Catchable errors |
| `classconstruction.cpp` | Null checks for skipped methods | Prevents segfaults |
| `astgen.cpp` | Support LoadString input in VisitCastValueToAnyType | Fixes 14,994 false skips |
| `astgen.cpp` | Iteration limit on predecessor traversal | Prevents infinite loops |
| `xabc.cpp` | SIGSEGV/SIGABRT signal handler | Catches remaining crashes |

## Test Results

Tested on AITO (问界) v2.0.9 `modules.abc` (10.6MB, 29,728 methods):

| Metric | Before | After |
|--------|--------|-------|
| Exit behavior | Crash on first class | Completes successfully |
| Output | None | 439,161 lines of ArkTS |
| Method coverage | 0% | ~85% (4,397 skipped) |
| Crashes caught by signal handler | N/A | 211 |

## Notes

- Release build (`is_debug=false`) recommended to disable internal assertions
- The signal handler approach (sigsetjmp/longjmp) is a pragmatic workaround; a fork-based isolation would be cleaner long-term
- 15% of methods are still skipped due to unsupported instruction patterns in AstGen

🤖 Generated with [Claude Code](https://claude.com/claude-code)